### PR TITLE
Add fallback when callsites does not include call directory

### DIFF
--- a/src/parsed-feature-loading.ts
+++ b/src/parsed-feature-loading.ts
@@ -204,7 +204,8 @@ export const parseFeature = (featureText: string, options?: Options): ParsedFeat
 export const loadFeature = (featureFilePath: string, options?: Options) => {
     options = getJestCucumberConfiguration(options);
 
-    const dirOfCaller = dirname(callsites()[1].getFileName() || '');
+	const traceCaller = callsites()[1];
+    const dirOfCaller = dirname(traceCaller ? traceCaller.getFileName() : '');
     const absoluteFeatureFilePath = resolve(options.loadRelativePath ? dirOfCaller : '', featureFilePath);
 
     try {


### PR DESCRIPTION
The issue: Because of our setup, tracing the directory which calls the `loadFeature` function seems impossible. The `callsites()` call in our case returns an array of one, requesting the second value returns undefined and the `getFileName` call causes `Error: Cannot read property 'getFileName' of undefined`.

The fix: Check if `callsites()[1]` exists before calling `getFileName()` and use fallback value otherwise.